### PR TITLE
Fix error on nightly rustc

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -4,10 +4,10 @@ use rocket_contrib::json::Json;
 use rocket_contrib::json;
 use serde::{Deserialize, Serialize};
 
-use r2d2_mongodb::mongodb::bson as bson;
+use r2d2_mongodb::mongodb as bson;
 use r2d2_mongodb::mongodb as mongodb;
 
-use bson::{doc, Bson};
+use bson::{bson, doc, Bson};
 use mongodb::db::ThreadedDatabase;
 
 use crate::data::security;

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -3,10 +3,10 @@ use rocket_contrib::json::Json;
 use rocket_contrib::json;
 use rocket_contrib::uuid::Uuid;
 
-use r2d2_mongodb::mongodb::bson as bson;
+use r2d2_mongodb::mongodb as bson;
 use r2d2_mongodb::mongodb as mongodb;
 
-use bson::{doc, Bson};
+use bson::{bson, doc, Bson};
 use mongodb::db::ThreadedDatabase;
 use mongodb::coll::options::{ReturnDocument, FindOneAndUpdateOptions};
 


### PR DESCRIPTION
Looks like this crate relies on a deprecated functionality in `rustc` - `use mongodb::bson` imports a private `extern crate` item from a different crate.
This was found during ecosystem testing in https://github.com/rust-lang/rust/pull/80763.
This PR fixes the issue.